### PR TITLE
Adds use of editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Settings which apply to all files
+[*]
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+# Settings for .py files
+[*.py]
+indent_style = space
+indent_size = 4
+
+# Settings for .travis.yml
+[.travis.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
A config file which controls text editor settings for those editors which support it. (e.g. indentation format, line ending characters)

More details at: http://editorconfig.org/

Plugins for supported editors here: http://editorconfig.org/#download