### PR TITLE
Pass mock player objects to strategy

### DIFF
--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -114,7 +114,10 @@ class Player(object):
         an error if no strategy method is defined (which are defined through
         class inheritance).
         """
-        s1, s2 = self.strategy(MockPlayer(opponent)), opponent.strategy(MockPlayer(self))
+        if not (s1 in axelrod.cheating_strategies or s2 in axelrod.cheating_strategies):    
+            s1, s2 = self.strategy(MockPlayer(opponent)), opponent.strategy(MockPlayer(self))
+        else:
+            s1, s2 = self.strategy(opponent), opponent.strategy(self)
         self.history.append(s1)
         opponent.history.append(s2)
 

--- a/axelrod/tournament.py
+++ b/axelrod/tournament.py
@@ -114,7 +114,7 @@ class Player(object):
         an error if no strategy method is defined (which are defined through
         class inheritance).
         """
-        s1, s2 = self.strategy(opponent), opponent.strategy(self)
+        s1, s2 = self.strategy(MockPlayer(opponent)), opponent.strategy(MockPlayer(self))
         self.history.append(s1)
         opponent.history.append(s2)
 
@@ -132,3 +132,11 @@ class Player(object):
     def __repr__(self):
         """The string method for the strategy."""
         return self.name
+
+class MockPlayer(object):
+    def __init__(self,player):
+        self.name = player.name
+        self.history = player.history[:]
+        self.score = player.score
+        self.stochastic = player.stochastic
+        self.strategy = player.strategy


### PR DESCRIPTION
So players can't cheat by modifying their opponents.

Cheating by looking at what the opponent's strategy will do is still possible (should it be?)