### PR TITLE
Revert "Adds Limited retaliate strategy"

### DIFF
--- a/axelrod/strategies/__init__.py
+++ b/axelrod/strategies/__init__.py
@@ -57,7 +57,6 @@ strategies = [
         OnceBitten,
         Golden,
         Retaliate,
-        LimitedRetaliate,
         ]
 
 #These are strategies that do not follow the rules of Axelrods tournement.

--- a/axelrod/strategies/retaliate.py
+++ b/axelrod/strategies/retaliate.py
@@ -3,9 +3,8 @@ from axelrod import Player
 
 class Retaliate(Player):
     """
-    A player that co-operates unless the opponent defects and wins.
-    It will then retaliate by defecting and won't stop until it has beaten
-    the opponent 10 times more often than it has lost.
+    A player starts by cooperating but will retaliate once the opponent
+    has won more than 10 percent times the number of defections the player has.
     """
     name = "Retaliate"
 
@@ -13,36 +12,5 @@ class Retaliate(Player):
         history = zip(self.history, opponent.history)
         if history.count(('C', 'D')) > history.count(('D', 'C')) * 0.1:
             return 'D'
-
-        return 'C'
-
-
-class LimitedRetaliate(Player):
-    """
-    A player that co-operates unless the opponent defects and wins.
-    It will then retaliate by defecting. It stops when either, it has beaten
-    the opponent 10 times more often that it has lost or it reaches the
-    retaliation limit (20 defections).
-    """
-    name = 'Limited Retaliate'
-    retaliation_limit = 20
-    retaliating = False
-    retaliation_count = 0
-
-    def strategy(self, opponent):
-        history = zip(self.history, opponent.history)
-        if history.count(('C', 'D')) > history.count(('D', 'C')) * 0.1:
-            self.retaliating = True
-        else:
-            self.retaliating = False
-            self.retaliation_count = 0
-
-        if self.retaliating:
-            if self.retaliation_count < self.retaliation_limit:
-                self.retaliation_count += 1
-                return 'D'
-            else:
-                self.retaliation_count = 0
-                self.retaliating = False
 
         return 'C'

--- a/axelrod/tests/test_retaliate.py
+++ b/axelrod/tests/test_retaliate.py
@@ -16,7 +16,7 @@ class TestRetaliate(unittest.TestCase):
 
     def test_effect_of_strategy(self):
         """
-        If opponent has defected and won more than 10 percent of the times that I have, defect.
+        If opponent has defected more than 10 percent of the time, defect.
         """
         P1 = axelrod.Retaliate()
         P2 = axelrod.Player()
@@ -36,49 +36,3 @@ class TestRetaliate(unittest.TestCase):
 
     def test_stochastic(self):
         self.assertFalse(axelrod.Retaliate().stochastic)
-
-
-class TestLimitedRetaliate(unittest.TestCase):
-    def test_initial_strategy(self):
-        """
-        Starts by cooperating
-        """
-        P1 = axelrod.LimitedRetaliate()
-        P2 = axelrod.Player()
-        self.assertEqual(P1.strategy(P2), 'C')
-
-    def test_effect_of_strategy(self):
-        """If opponent has never defected, co-operate"""
-        P1 = axelrod.LimitedRetaliate()
-        P2 = axelrod.Player()
-        P1.history = ['C', 'C', 'C', 'C']
-        P2.history = ['C', 'C', 'C', 'C']
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertFalse(P1.retaliating)
-
-        """If opponent has previously defected and won, defect and be retaliating"""
-        P1.history = ['C', 'C', 'C', 'C', 'D']
-        P2.history = ['C', 'C', 'C', 'D', 'C']
-        self.assertEqual(P1.strategy(P2), 'D')
-        self.assertTrue(P1.retaliating)
-
-        """If opponent has just defected and won, defect and be retaliating"""
-        P1.history = ['C', 'C', 'C', 'C', 'C', 'C']
-        P2.history = ['C', 'C', 'C', 'C', 'C', 'D']
-        self.assertEqual(P1.strategy(P2), 'D')
-        self.assertTrue(P1.retaliating)
-
-        """If I've hit the limit for retaliation attempts, co-operate"""
-        P1.history = ['C', 'C', 'C', 'C', 'D']
-        P2.history = ['C', 'C', 'C', 'D', 'C']
-        P1.retaliation_count = 20
-        self.assertEqual(P1.strategy(P2), 'C')
-        self.assertFalse(P1.retaliating)
-
-
-    def test_representation(self):
-        P1 = axelrod.LimitedRetaliate()
-        self.assertEqual(str(P1), 'Limited Retaliate')
-
-    def test_stochastic(self):
-        self.assertFalse(axelrod.LimitedRetaliate().stochastic)


### PR DESCRIPTION
I hit merge before I looked at the code. Sorry. This needs it's own `reset` method does it not? Otherwise the count and boolean won't be right? (They might be because of the strategy method but in that case I'd still like to see a test of what happens when it plays a second game: ideally it's own reset method would be ideal). Apologies if I'm missing something.